### PR TITLE
Contract improvements

### DIFF
--- a/contracts/TokenMigration.aes
+++ b/contracts/TokenMigration.aes
@@ -2,13 +2,15 @@ payable contract TokenMigration =
 
     datatype event = Migrated(bytes(20), address, int)
 
+    type set('a) = map('a, unit)
+
     record state =
         { root_hash: string,
           map_temp_root: map(address,string),
           migrations_count: int,
           owner: address,
-          map_transfered_accounts: map(string, bool),
-          map_current_caller: map(string, bool),
+          map_transfered_accounts: set(string),
+          map_current_caller: set(string),
           map_index: map(address, int) }
 
     entrypoint init(root_hash: string, count: int) : state =
@@ -23,11 +25,11 @@ payable contract TokenMigration =
     // 'eth_addr_str' should be passed as uppercase
     payable stateful entrypoint migrate(amount_of_tokens: int, ae_address: address, leaf_index: int, siblings: list(string), eth_addr_str: string, eth_address: bytes(20), sig: bytes(65), msg_hash: hash) =
 
-        require(!Map.lookup_default(eth_addr_str, state.map_transfered_accounts, false), "This account has already transferred its tokens")
+        require(!Map.member(eth_addr_str, state.map_transfered_accounts), "This account has already transferred its tokens")
         require(Address.is_payable(ae_address), "Passed AE address is not payable")
         // request from this eth address is in progress
-        require(!Map.lookup_default(eth_addr_str, state.map_current_caller, false), "There is a request from this ethereum address")
-        put(state{map_current_caller[eth_addr_str] = true})
+        require(!Map.member(eth_addr_str, state.map_current_caller), "There is a request from this ethereum address")
+        put(state{map_current_caller[eth_addr_str] = ()})
 
         // why this does not work?
         // require(contained_in_merkle_tree(String.concat("0X", Bytes.to_str(eth_address)), amount_of_tokens, leaf_index, siblings), "From provided data, cannot be generated same root!")
@@ -54,7 +56,7 @@ payable contract TokenMigration =
 
         transfer(ae_address, amount_of_tokens)
         put(state{migrations_count = state.migrations_count + 1})
-        put(state{map_transfered_accounts[eth_addr_str] = true})
+        put(state{map_transfered_accounts[eth_addr_str] = ()})
 
         Chain.event(Migrated(eth_address, ae_address, amount_of_tokens))
         put(state{map_current_caller = Map.delete(eth_addr_str, state.map_current_caller)})
@@ -124,7 +126,7 @@ payable contract TokenMigration =
     entrypoint balance() = Contract.balance
     entrypoint root_hash() = state.root_hash
     entrypoint migrations_count() = state.migrations_count
-    entrypoint is_migrated(eth_address: string) = Map.lookup_default(eth_address, state.map_transfered_accounts, false)
+    entrypoint is_migrated(eth_address: string) = Map.member(eth_address, state.map_transfered_accounts)
 
     function only_owner() =
         require(Call.caller == state.owner, "Owner require")

--- a/contracts/TokenMigration.aes
+++ b/contracts/TokenMigration.aes
@@ -2,8 +2,8 @@ payable contract TokenMigration =
 
     datatype event = Migrated(bytes(20), address, int)
 
-    record state = 
-        { root_hash: string, 
+    record state =
+        { root_hash: string,
           map_temp_root: map(address,string),
           migrations_count: int,
           owner: address,
@@ -11,7 +11,7 @@ payable contract TokenMigration =
           map_current_caller: map(string, bool),
           map_index: map(address, int) }
 
-    entrypoint init(root_hash: string, count: int) : state = 
+    entrypoint init(root_hash: string, count: int) : state =
         { root_hash = root_hash,
           map_temp_root = {},
           migrations_count = count,
@@ -29,7 +29,7 @@ payable contract TokenMigration =
         require(!Map.lookup_default(eth_addr_str, state.map_current_caller, false), "There is a request from this ethereum address")
         put(state{map_current_caller[eth_addr_str] = true})
 
-        // why this does not work? 
+        // why this does not work?
         // require(contained_in_merkle_tree(String.concat("0X", Bytes.to_str(eth_address)), amount_of_tokens, leaf_index, siblings), "From provided data, cannot be generated same root!")
 
         // should successfully generate same merkle tree root hash
@@ -50,7 +50,7 @@ payable contract TokenMigration =
 
         require(are_equal, "Mismatch between passed eth address and recovered one")
 
-        
+
 
         transfer(ae_address, amount_of_tokens)
         put(state{migrations_count = state.migrations_count + 1})
@@ -77,7 +77,7 @@ payable contract TokenMigration =
         let data = Bytes.to_str(String.sha3(data)) // hash -> str
 
         //let data = Bytes.to_str(String.sha3(String.concat(eth_addr, ":", tokens))) // not working ?!
-        
+
         // set hashed concatenated data, merkle tree leaf root
         put(state{map_temp_root[Call.caller] = data})
         // set merkle tree leaf index

--- a/contracts/TokenMigration.aes
+++ b/contracts/TokenMigration.aes
@@ -20,9 +20,6 @@ payable contract TokenMigration =
         require(!Map.member(eth_addr_str, state.map_transfered_accounts), "This account has already transferred its tokens")
         require(Address.is_payable(ae_address), "Passed AE address is not payable")
 
-        // why this does not work?
-        // require(contained_in_merkle_tree(String.concat("0X", Bytes.to_str(eth_address)), amount_of_tokens, leaf_index, siblings), "From provided data, cannot be generated same root!")
-
         // should successfully generate same merkle tree root hash
         let is_contained = contained_in_merkle_tree(eth_addr_str, amount_of_tokens, leaf_index, siblings)
         require(is_contained, "From provided data, cannot be generated same root")
@@ -35,9 +32,7 @@ payable contract TokenMigration =
 
         require(are_equal, "Mismatch between passed eth address and recovered one")
 
-
-
-        transfer(ae_address, amount_of_tokens)
+        Chain.spend(ae_address, amount_of_tokens)
         put(state{migrations_count = state.migrations_count + 1})
         put(state{map_transfered_accounts[eth_addr_str] = ()})
 
@@ -47,10 +42,6 @@ payable contract TokenMigration =
 
     function get_signer(msg_hash: hash, sig: bytes(65)) =
         Crypto.ecrecover_secp256k1(msg_hash, sig)
-
-    payable stateful function transfer(to: address, amount: int) =
-        Chain.spend(to, amount)
-        amount
 
     entrypoint contained_in_merkle_tree(eth_addr: string, tokens: int, leaf_index: int, siblings: list(string) ) =
         // concat data => eth_Addr:tokens => concatenated data

--- a/contracts/TokenMigration.aes
+++ b/contracts/TokenMigration.aes
@@ -65,12 +65,15 @@ payable contract TokenMigration =
                 let data = if (index mod 2 == 1) String.concat(el, root) else String.concat(root, el)
                 calculate_root(els, index / 2, Bytes.to_str(String.sha3(data)))
 
-    payable stateful entrypoint deposit() = Call.value
+    // Test only?
+    payable entrypoint deposit() = Call.value
 
+    // Test only?
     stateful entrypoint update_root(new_root: string) =
         only_owner()
         put(state{root_hash = new_root})
 
+    // Test only?
     stateful entrypoint update_migrations_count(new_count: int) =
         only_owner()
         put(state{migrations_count = new_count})

--- a/contracts/TokenMigration.aes
+++ b/contracts/TokenMigration.aes
@@ -6,39 +6,27 @@ payable contract TokenMigration =
 
     record state =
         { root_hash: string,
-          map_temp_root: map(address,string),
           migrations_count: int,
           owner: address,
-          map_transfered_accounts: set(string),
-          map_current_caller: set(string),
-          map_index: map(address, int) }
+          map_transfered_accounts: set(string) }
 
     entrypoint init(root_hash: string, count: int) : state =
         { root_hash = root_hash,
-          map_temp_root = {},
           migrations_count = count,
           owner = Call.origin,
-          map_transfered_accounts = {},
-          map_current_caller = {},
-          map_index = {} }
+          map_transfered_accounts = {} }
 
     // 'eth_addr_str' should be passed as uppercase
     payable stateful entrypoint migrate(amount_of_tokens: int, ae_address: address, leaf_index: int, siblings: list(string), eth_addr_str: string, eth_address: bytes(20), sig: bytes(65), msg_hash: hash) =
 
         require(!Map.member(eth_addr_str, state.map_transfered_accounts), "This account has already transferred its tokens")
         require(Address.is_payable(ae_address), "Passed AE address is not payable")
-        // request from this eth address is in progress
-        require(!Map.member(eth_addr_str, state.map_current_caller), "There is a request from this ethereum address")
-        put(state{map_current_caller[eth_addr_str] = ()})
 
         // why this does not work?
         // require(contained_in_merkle_tree(String.concat("0X", Bytes.to_str(eth_address)), amount_of_tokens, leaf_index, siblings), "From provided data, cannot be generated same root!")
 
         // should successfully generate same merkle tree root hash
         let is_contained = contained_in_merkle_tree(eth_addr_str, Int.to_str(amount_of_tokens), leaf_index, siblings)
-        if (!is_contained)
-            put(state{map_current_caller = Map.delete(eth_addr_str, state.map_current_caller)})
-
         require(is_contained, "From provided data, cannot be generated same root")
 
         // extract signer of signature, should be same address that holds tokens
@@ -46,9 +34,6 @@ payable contract TokenMigration =
         let are_equal = switch (recovered_address)
                             None => false
                             Some(recovered) => recovered == eth_address
-
-        if (!are_equal)
-            put(state{map_current_caller = Map.delete(eth_addr_str, state.map_current_caller)})
 
         require(are_equal, "Mismatch between passed eth address and recovered one")
 
@@ -59,7 +44,6 @@ payable contract TokenMigration =
         put(state{map_transfered_accounts[eth_addr_str] = ()})
 
         Chain.event(Migrated(eth_address, ae_address, amount_of_tokens))
-        put(state{map_current_caller = Map.delete(eth_addr_str, state.map_current_caller)})
 
         state.migrations_count
 
@@ -70,7 +54,7 @@ payable contract TokenMigration =
         Chain.spend(to, amount)
         amount
 
-    stateful entrypoint contained_in_merkle_tree(eth_addr: string, tokens: string, leaf_index: int, siblings: list(string) ) =
+    entrypoint contained_in_merkle_tree(eth_addr: string, tokens: string, leaf_index: int, siblings: list(string) ) =
         // concat data => eth_Addr:tokens => concatenated data
         let data = String.concat(eth_addr, ":")
         let data = String.concat(data, tokens)
@@ -80,38 +64,17 @@ payable contract TokenMigration =
 
         //let data = Bytes.to_str(String.sha3(String.concat(eth_addr, ":", tokens))) // not working ?!
 
-        // set hashed concatenated data, merkle tree leaf root
-        put(state{map_temp_root[Call.caller] = data})
-        // set merkle tree leaf index
-        put(state{map_index[Call.caller] = leaf_index})
-        // iterate through merkle tree siblings(hashes of neighbor's leaf and rest of the nodes)
-        map_action(calculate_root, siblings)
+        let root = calculate_root(siblings, leaf_index, data)
 
         // genarated merkle tree hash should be same as inited one
-        let contained_in_tree = state.map_temp_root[Call.caller] == state.root_hash
+        root == state.root_hash
 
-        // delete current request data
-        put(state{map_temp_root = Map.delete(Call.caller, state.map_temp_root)})
-        put(state{map_index = Map.delete(Call.caller, state.map_index)})
-
-        contained_in_tree
-
-    // iteration func
-    stateful function map_action(f : 'a => 'b, l : list('a)) : list('b) =
-        switch(l)
-            [] => []
-            e :: l' => f(e) :: map_action(f, l')
-
-    stateful function calculate_root(el: string) =
-        // want to pass 'index' and 'temp_root' like params, not like state variables, any suggestions?
-        if(state.map_index[Call.caller] mod 2 == 1)
-            put(state{map_temp_root[Call.caller] = Bytes.to_str(String.sha3(String.concat(el, state.map_temp_root[Call.caller])))})
-        else
-            put(state{map_temp_root[Call.caller] = Bytes.to_str(String.sha3(String.concat(state.map_temp_root[Call.caller], el)))})
-
-        put(state{ map_index[Call.caller] = state.map_index[Call.caller] / 2 })
-
-        ()
+    function calculate_root(els : list(string), index : int, root : string) =
+        switch(els)
+            []        => root
+            el :: els =>
+                let data = if (index mod 2 == 1) String.concat(el, root) else String.concat(root, el)
+                calculate_root(els, index / 2, Bytes.to_str(String.sha3(data)))
 
     payable stateful entrypoint deposit() = Call.value
 

--- a/contracts/TokenMigration.aes
+++ b/contracts/TokenMigration.aes
@@ -7,13 +7,11 @@ payable contract TokenMigration =
     record state =
         { root_hash: string,
           migrations_count: int,
-          owner: address,
           map_transfered_accounts: set(string) }
 
     entrypoint init(root_hash: string, count: int) : state =
         { root_hash = root_hash,
           migrations_count = count,
-          owner = Call.origin,
           map_transfered_accounts = {} }
 
     // 'eth_addr_str' should be passed as uppercase
@@ -92,4 +90,4 @@ payable contract TokenMigration =
     entrypoint is_migrated(eth_address: string) = Map.member(eth_address, state.map_transfered_accounts)
 
     function only_owner() =
-        require(Call.caller == state.owner, "Owner require")
+        require(Call.caller == Contract.creator, "Owner require")

--- a/contracts/TokenMigration.aes
+++ b/contracts/TokenMigration.aes
@@ -24,7 +24,7 @@ payable contract TokenMigration =
         // require(contained_in_merkle_tree(String.concat("0X", Bytes.to_str(eth_address)), amount_of_tokens, leaf_index, siblings), "From provided data, cannot be generated same root!")
 
         // should successfully generate same merkle tree root hash
-        let is_contained = contained_in_merkle_tree(eth_addr_str, Int.to_str(amount_of_tokens), leaf_index, siblings)
+        let is_contained = contained_in_merkle_tree(eth_addr_str, amount_of_tokens, leaf_index, siblings)
         require(is_contained, "From provided data, cannot be generated same root")
 
         // extract signer of signature, should be same address that holds tokens
@@ -52,10 +52,10 @@ payable contract TokenMigration =
         Chain.spend(to, amount)
         amount
 
-    entrypoint contained_in_merkle_tree(eth_addr: string, tokens: string, leaf_index: int, siblings: list(string) ) =
+    entrypoint contained_in_merkle_tree(eth_addr: string, tokens: int, leaf_index: int, siblings: list(string) ) =
         // concat data => eth_Addr:tokens => concatenated data
         let data = String.concat(eth_addr, ":")
-        let data = String.concat(data, tokens)
+        let data = String.concat(data, Int.to_str(tokens))
 
         // concatenated data -> hash
         let data = Bytes.to_str(String.sha3(data)) // hash -> str


### PR DESCRIPTION
Some improvements to migration contract
- Use `map(string, unit)` instead of `map(string, bool)`
- Get rid of unnecessary state components
- Minor cleanup